### PR TITLE
Update PlatformIO board from Uno to Mega

### DIFF
--- a/Maze-solving-robot/platformio.ini
+++ b/Maze-solving-robot/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:uno]
+[env:megaatmega2560]
 platform = atmelavr
-board = uno
+board = megaatmega2560
 framework = arduino


### PR DESCRIPTION
Updates the platformio.ini file to change the target board from uno to megaatmega2560.