### PR TITLE
Add initial Wokwi configuration and diagram for Arduino Mega project

### DIFF
--- a/Maze-solving-robot/diagram.json
+++ b/Maze-solving-robot/diagram.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "author": "Group 4",
+  "editor": "wokwi",
+  "parts": [
+    { "type": "wokwi-arduino-mega", "id": "mega", "top": 0, "left": 0, "attrs": {} },
+    { "type": "wokwi-led", "id": "led1", "top": -90, "left": 128.6, "attrs": { "color": "red" } }
+  ],
+  "connections": [
+    [ "led1:C", "mega:GND.1", "black", [ "v19.2", "h-76.4" ] ],
+    [ "led1:A", "mega:8", "red", [ "v19.2", "h19.2" ] ]
+  ],
+  "dependencies": {}
+}

--- a/Maze-solving-robot/wokwi.toml
+++ b/Maze-solving-robot/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = ".pio/build/megaatmega2560/firmware.hex"
+elf = ".pio/build/megaatmega2560/firmware.elf"


### PR DESCRIPTION
**Hardware diagram setup:**
- Added a new `diagram.json` file that defines the hardware layout, including an Arduino Mega and a red LED, with wiring connections specified.

**Simulation environment configuration:**
- Added a `wokwi.toml` file to configure the Wokwi simulator, specifying firmware and ELF file locations for the Arduino Mega.